### PR TITLE
Added generation of random powder data.

### DIFF
--- a/dream.py
+++ b/dream.py
@@ -194,25 +194,6 @@ class DreamTest:
 
         return pixel_coords
 
-    def generate_data_test(self, n_events):
-        """
-        This method generates n_events of sparse tof data.
-        To be expanded to generate plausible data into some Bragg peaks in the future
-        
-        Parameters
-        ----------
-            n_events: int
-                Number of events to generate and add to current dataset self.d
-        """
-
-        # Add some events
-        # Note: d.coords[Dim.Tof] gives the "dense" TOF coord, not the event-TOFs
-        self.d['sample'].coords[Dim.Tof][Dim.Position, 0].values = np.arange(n_events)
-        self.d['sample'].coords[Dim.Tof][Dim.Position, 1].values = np.arange(n_events)
-        #self.d['sample'].coords[Dim.Tof][Dim.Position, [1,2]].values = np.array((np.arange(n_events), np.array([3, 3, 3])))
-        # The following should be equivalent but does not work yet, see scipp/#290
-        # d['sample'].coords[Dim.Tof].values[1] = np.arange(10)
-         
     def _generate_random_sample(self, n_peaks, d_range=[0.5, 10], deltad_over_d_range=[0.1, 0.5], strength_range=[1, 10]):
         """
         Generate a random series of Bragg peaks. They will be

--- a/dream.py
+++ b/dream.py
@@ -1,12 +1,66 @@
+import time
 import numpy as np
 import scipp as sc
 from scipp import Dim
+
+class bragg_peak:
+    """
+    Class to hold a Bragg peak generator with a given d_spacing,
+    width and strength. The strength is a unphysical description
+    of its strength, and has no absolute meaning, but is relative
+    to the total strength observed.
+    The Bragg peak can generate a numpy array of d_spacing values
+    with a length found from the strength of the peak and a given
+    conversion factor between strength and expected events.
+    The number of events is drawn from a poisson distribution.
+    """
+    def __init__(self, d_spacing, d_width, strength):
+        """
+        Initialize a Bragg peak
+        
+        Parameters
+        ----------
+            d_spacing: float
+                Central d_spacing of the peak
+            
+            d_width: float
+                Width of the gaussian d_spacing distribution
+            
+            strength: float
+                Strength of the Bragg peak (relative)
+        """
+    
+        self.d_spacing = d_spacing
+        self.d_width = d_width
+        self.strength = strength
+        
+    def generate_events(self, events_per_strength):
+        """
+        Will generator a poisson distributed number of events with
+        expectation value: strength*events_per_strength.
+        The events is distributed around the central d_spacing value
+        with the given d_spacing width.
+        
+        Parameters
+        ----------
+            events_per_strength: float
+                Number of events expected per strength of the Bragg peak
+        """
+
+        n_events = np.random.poisson(self.strength*events_per_strength)
+        
+        return_value = self.d_spacing + self.d_width*np.random.randn(n_events)
+        
+        if len(return_value) >0 and np.min(return_value) < 0:
+            print("Negative d_spacing returned")
+        
+        return return_value
 
 class DreamTest:
     """
     Class for setting up a simplified version of the DREAM instrument using scipp.
     """
-    def __init__(self, n_pixel, source_sample_dist=76.55, detector_radius=4):
+    def __init__(self, n_pixel, source_sample_dist=76.55, detector_radius=1.25, n_rows=1):
         """
         Initialize the simplified DREAM instrument.
         Sets up a scipp dataset including:
@@ -25,13 +79,16 @@ class DreamTest:
 
             detector_radius: double
                 Radius of detector (centered on sample)
+                
+            n_rows: int
+                Number of rows in the detector
         """
     
         # Includes labels 'component_info', a special name that `scipp.neutron.convert` will inspect for instrument information.
         self.d = sc.Dataset(
             coords={
                 Dim.Position:
-                self._make_cylinder_coords(n_pixel, 1, radius=detector_radius),
+                self._make_cylinder_coords(n_pixel, n_rows, radius=detector_radius),
                 # TOF is optional, Mantid always has this but not needed at this point
                 Dim.Tof:
                 sc.Variable(dims=[Dim.Tof], values=np.arange(10.0), unit=sc.units.us)
@@ -48,9 +105,16 @@ class DreamTest:
                            unit=sc.units.us)
         self.d['sample'] = sc.DataArray(coords={Dim.Tof: tofs})
     
+        # source_sample_dist needed in data generation
+        self.source_sample_dist = source_sample_dist
+    
         # Set up dspacing and hist variable
         self.dspacing = None
         self.hist = None
+    
+        # d spacings for sample
+        self.sample_bragg_peaks = []
+        self.sample_bragg_peaks_d = []
 
     def _make_component_info(self, source_pos, sample_pos):
         """
@@ -130,7 +194,7 @@ class DreamTest:
 
         return pixel_coords
 
-    def generate_data(self, n_events):
+    def generate_data_test(self, n_events):
         """
         This method generates n_events of sparse tof data.
         To be expanded to generate plausible data into some Bragg peaks in the future
@@ -144,40 +208,193 @@ class DreamTest:
         # Add some events
         # Note: d.coords[Dim.Tof] gives the "dense" TOF coord, not the event-TOFs
         self.d['sample'].coords[Dim.Tof][Dim.Position, 0].values = np.arange(n_events)
+        self.d['sample'].coords[Dim.Tof][Dim.Position, 1].values = np.arange(n_events)
+        #self.d['sample'].coords[Dim.Tof][Dim.Position, [1,2]].values = np.array((np.arange(n_events), np.array([3, 3, 3])))
         # The following should be equivalent but does not work yet, see scipp/#290
-         # d['sample'].coords[Dim.Tof].values[1] = np.arange(10)
-
-    def convert_to_dspacing(self):
+        # d['sample'].coords[Dim.Tof].values[1] = np.arange(10)
+         
+    def _generate_random_sample(self, n_peaks, d_range=[0.5, 10], deltad_over_d_range=[0.1, 0.5], strength_range=[1, 10]):
         """
-        This methods converts d to d_spacing using scipp-neutron convert
+        Generate a random series of Bragg peaks. They will be
+        stored sorted with respect to d spacing to allow the
+        data generation algorithm to search it faster.
+        
+        Parameters
+        ----------
+            n_peaks: int
+                Number of Bragg peaks to generate
+        
+            d_range: List[2] [Å]
+                Start and end of allowed d range interval
+            
+            deltad_over_d_range: List[2] [%]
+                Start and end of allowed delta d over d range (in %, typical less than 1%)
+        
+            strength_range: List[2] [arb]
+                Start and end of allowed strength interval (relative peak strength)
         """
+        d_array = []
+        for _ in range(n_peaks):
+            d_array.append(np.random.uniform(d_range[0], d_range[1]))
+        
+        # Sort the generated d values, ascending
+        d_array.sort()
+        self.sample_bragg_peaks_d = d_array
+    
+        # Generate each bragg peak based on its d spacing, add random width and strength
+        for d_value in d_array:
+            dover_d_value = np.random.uniform(deltad_over_d_range[0], deltad_over_d_range[1])*d_value/100
+            strength_value = np.random.uniform(strength_range[0], strength_range[1])
+            self.sample_bragg_peaks.append(bragg_peak(d_value, dover_d_value, strength_value))
 
-        self.dspacing = sc.neutron.convert(self.d, Dim.Tof, Dim.DSpacing)
-        return self.dspacing
-
-    def convert_to_histogram(self):
+    def generate_data_pseudo(self, n_events, wavelength_width=3.6, wavelength_center=3.0,
+                             effective_pulse_length=1E-4, progress_bar=True, verbose=True):
         """
-        Convert to histogram (not used yet)
+        Generate pseudo realistic distribution based on DREAM parameters.
+        The wavelength width needs to be a bit less than normal to contain
+        the time distribution within the allowed frame due to no simulated
+        chopper system and that Bragg peaks with a center within the
+        wavelength range is sampled over their entire gaussian.
+        The number of events generated will not exactly match n_events, as
+        the events are drawn from many poisson distributions with an
+        expectation value equal to n_events. For typical n_event numbers,
+        the difference is much less than 1%.
+        
+        Parameters
+        ----------
+            n_events: int
+                Number of events to generate
+        
+            wavelength_width: float [Å]
+                Width of wavelength frame of the instrument, 3.6 Å should fill the frame with perfect source
+            
+            wavelength_center: float [Å]
+                Center of wavelength frame of the instrument, typicall around 2.5-3.0 Å
+            
+            effective_pulse_length: float [s]
+                Effective pulse length (after choppers have modified the pulse), between 10 us and 2.86 ms
+        
+            progress_bar: Boolean
+                Set to True for a progress bar of data generation to be written to terminal
+            
+            verbose: Boolean
+                Set to True for a short analysis of generated data to be written to terminal
         """
-        self.hist = sc.histogram(self.dspacing, dspacing.coords[Dim.DSpacing])
-        return self.hist
+    
+        if wavelength_center - wavelength_width/2.0 < 0:
+            raise ValueError("Provided wavelength band with negative wavelengths.")
+    
+        # get pixel theta:
+        positions = np.array(dream.d.coords[Dim.Position].values)
+        n_positions = (len(positions))
+        z_dir = np.zeros((n_positions, 3))
+        z_dir[:,2] = 1.0
+        position_lengths = np.sqrt(np.sum(positions**2, axis=1))
+        position_zdir_dots = np.sum(positions*z_dir, axis=1)
+        tthetas = 180/np.pi*np.array(np.arccos(position_zdir_dots/position_lengths))
+        thetas = 0.5*tthetas
+        
+        # Find allowed bragg peaks for each pixel and find total strength in order to normalize
+        allowed = np.full((n_positions, len(self.sample_bragg_peaks)), False)
+        pixel_strengths = np.zeros(n_positions)
+        count = 0
+        for bragg_peak in self.sample_bragg_peaks:
+            wavelength = 2.0*bragg_peak.d_spacing*np.sin(thetas)
+            allowed[:,count] = np.logical_and(wavelength < wavelength_center + wavelength_width/2.0,
+                                              wavelength > wavelength_center - wavelength_width/2.0)
+            pixel_strengths[allowed[:,count]] += bragg_peak.strength
+            count += 1
+            
+        # Now we have pixel_strength as indicator for relative intensity in each peak (assuming relatively narrow peaks)
+        total_strength = np.sum(pixel_strengths)
+        events_per_strength = n_events / total_strength
 
-    #def data_reduction(self):
-        # "DiffractionFocussing" == sum? (not available yet)
-        # focussed = sc.sum(hist, Dim.Position)
+        # Calculate distance from source to each pixel when scattered in sample
+        source_to_pixel = self.source_sample_dist + position_lengths
+        
+        # Prepare progress bar and timing of most time consuming loop
+        progress_fraction = int(n_positions/10)
+        progress_count = 0
+        start_time = time.time()
+        
+        print("Generating sparse data for each pixel")
+        # For each pixel we check all allowed bragg peaks and generate a poisson distributed number of events from each
+        for pixel_id in range(n_positions):
+        
+            if progress_bar and pixel_id % progress_fraction == 0:
+                print(str(progress_count*10) + "%")
+                progress_count += 1
+            
+            allowed_bragg_peaks = allowed[pixel_id,:]
+            wavelengths = []
+            for bragg_peak_id in np.arange(len(allowed_bragg_peaks))[allowed_bragg_peaks]:
+                returned_wavelengths = 2.0*np.sin(thetas[pixel_id])*self.sample_bragg_peaks[bragg_peak_id].generate_events(events_per_strength)
+                if len(returned_wavelengths) > 0:
+                    wavelengths.append(returned_wavelengths)
+        
+            # Will add the events to the sparse Tof dimension if any are found
+            if len(wavelengths) > 0:
+                wavelengths = np.concatenate(wavelengths)
+                # convert wavelengths to time
+                neutron_speeds = 3956.0 / wavelengths # [Å] -> [m/s]
+                # convert to travel time
+                travel_time = source_to_pixel[pixel_id] / neutron_speeds # [m] / [m/s] -> [s]
+                # add some time uncertainty from pulse length (realistically it will be reduced by chopper settings)
+                event_times = travel_time + effective_pulse_length*np.random.randn(len(travel_time))
+                # Write the events to the pixel with the current pixel_id
+                self.d['sample'].coords[Dim.Tof][Dim.Position, pixel_id].values = event_times*1E6 # [s] -> [us] convert to us
 
+        end_time = time.time()
+        print("Data was generated in " +  "%.2f" % (end_time - start_time) + " seconds.")
+        
+        if verbose:
+            sum_times = 0
+            min_time = None
+            max_time = 0
+            for array in np.array(self.d["sample"].coords[Dim.Tof].values):
+                sum_times += len(array)
+                if len(array) > 0:
+                    if min_time is None or np.min(array) < min_time:
+                        min_time = np.min(array)
+                    if np.max(array) > max_time:
+                        max_time = np.max(array)
 
-n_pixel = 1000
-n_events = 10
+                    # Should never happen
+                    if np.min(array) < 0:
+                        print("Negative time found in array!")
+                        print(array)
+
+            #print(sum_times)
+            n_pixels_read = len(np.array(self.d["sample"].coords[Dim.Tof].values))
+            print("Distributed " + str(sum_times) + " events into " + str(n_pixels_read) + " pixels.")
+            print("Minimum time recorded: " + "%.0f" % min_time + " us")
+            print("Maximum time recorded: " + "%.0f" % max_time + " us")
+            frame_time = max_time - min_time
+            fraction_of_optimal = frame_time*14/1E6
+            print("Corresponding to a frame of: " + "%.0f" % frame_time + " us, which is "
+                  + "%.1f" % (fraction_of_optimal*100) + "% of the available frame")
+
+# Script for demonstration of event generation
+n_pixel = int(1E5)
+n_events = int(1E7)
 
 dream = DreamTest(n_pixel)
 print("Dataset with pixels initialzied")
 print(dream.d)
 
-dream.generate_data(n_events)
-print("Dataset with some sparse tof data")
+print("Generating random sample")
+dream._generate_random_sample(15)
+
+print("Generating random sparse data")
+dream.generate_data_pseudo(n_events)
 print(dream.d)
 
-dspacing = dream.convert_to_dspacing()
-print("Dataset converted to dspacing")
-print(dspacing)
+dspacing = sc.neutron.convert(dream.d, Dim.Tof, Dim.DSpacing)
+
+# Conversion to histogram still does not work, even though data is realistic
+#histogram = sc.histogram(dspacing, dspacing.coords[Dim.DSpacing])
+
+# "DiffractionFocussing" == sum? (not available yet)
+# focussed = sc.sum(hist, Dim.Position)
+
+


### PR DESCRIPTION
A number of random Bragg peaks are defined with a given range of
d spacings, delta d over d values and relative strengths.
The wavelength frame is defined and the Bragg peaks available for
each pixel is identified. A poisson distributed random number of
events are then drawn from each bragg peak, each with a gaussion
distribution of d spacings. The instrument length, detector
distance and a random source origin time is used to calculate the
corresponding time for the event.

This provides a dataset with somewhat realistic correlations
between time and theta value of each pixel. There is no background,
but this could be added if desired.

The performance scaling of the code is problematic for the number
of pixels generated, but the scaling for number of events is good.

1E7 events in 1E5 pixels takes 15 seconds on my laptop. Going to
5E5 pixels the run time is around 6 minutes.