### PR TITLE
Function that can load a nexus event file using scipp/mantid and

### DIFF
--- a/expand_load.py
+++ b/expand_load.py
@@ -1,0 +1,135 @@
+import math
+import scipp as sc
+from scipp import Dim
+import numpy as np
+import matplotlib
+from scipp.compat.mantid import load
+
+def expand_data_file(filename, n_pixels, n_events=None, time_noise_us=200, verbose=False):
+    """
+    Function that loads an event based nexus data file using mantid through
+    scipp and adds additional pixels / events. The pixels in the datafile are
+    replicated until the required number is reached. For each pixel the original
+    sparse data is added, but with a user defined random noise. If a number of
+    events is specified, the original data is added multiple times with new
+    random time noise each time. Exceptions are raised if n_pixels or n_events
+    are too small. A scipp dataset is returned.
+
+    Arguments
+    ---------
+
+    filename : str
+        Filename of nexus event datafile to be loaded
+
+    n_pixels : int
+        Number of pixel for returned scipp dataset, must be larger than original
+
+    Keyword Arguments
+    -----------------
+
+    n_events : int
+        Number of events for returned scipp dataset, must be sufficiently large
+
+    time_noise_us : float
+        Width of gaussian noise added to time of flight data
+
+    verbose : Boolean
+        Sets verbose mode which prints additional information
+
+    """
+    # Make sure n_pixels and n_events are ints or can at least be converted
+    n_pixels = int(n_pixels)
+    n_events = int(n_events)
+
+    d = sc.Dataset()
+    d["loaded_data"] = load(filename=filename, load_pulse_times=False)
+    if verbose:
+        print("Loaded dataset")
+        print(d)
+
+    original_length = len(np.array(d.coords[Dim.Position].values))
+    original_events = 0
+    for pixel_id in range(original_length):
+        original_events += len(np.array(d["loaded_data"].coords[Dim.Tof].values[pixel_id]))
+
+    if n_pixels < original_length:
+        raise ValueError("n_pixel less than number of pixels in existing datafile")
+
+    expected_events = n_pixels/original_length*original_events
+    if n_events is not None and n_events < expected_events:
+        print(n_pixels, n_events)
+        print(original_length, original_events)
+        raise ValueError("n_events too small, not all pixels will get events")
+
+    # Adding pixels to dataset
+    current_length = original_length
+    positions_var = d.coords[Dim.Position]
+    combined_var = positions_var.copy()
+    while (current_length <= n_pixels - original_length):
+        current_length += original_length
+        combined_var = sc.concatenate(combined_var, positions_var, Dim.Position)
+
+    remaining_length = n_pixels - current_length
+
+    if remaining_length > 0:
+        combined_var = sc.concatenate(combined_var, positions_var[Dim.Position, 0:remaining_length], Dim.Position)
+
+    ds = sc.Dataset(coords={Dim.Position: combined_var})
+
+    if verbose:
+        print("Generated dataset before tof events are added")
+        print(ds)
+
+    # Adding sparse data to dataset
+    tofs = sc.Variable(dims=[Dim.Position, Dim.Tof], shape=[n_pixels, sc.Dimensions.Sparse], unit=sc.units.us)
+    ds["measurement"] = sc.DataArray(coords={Dim.Tof: tofs})
+
+    added_events = 0
+    while n_events is None or added_events < n_events: # keep adding sparse data until enough events reached
+        original_id = 0
+        for pixel_id in range(n_pixels):
+            # For each pixel, grab the events from the original file
+            pos_n_events = len(np.array(d["loaded_data"].coords[Dim.Tof].values[original_id]))
+
+            # If any events present, add random noise and append them as sparse data
+            if pos_n_events > 0:
+                noise = np.random.normal(pos_n_events)*time_noise_us
+                new_values = np.array(d["loaded_data"].coords[Dim.Tof].values[original_id]) + noise
+
+                ds["measurement"].coords[Dim.Tof][Dim.Position, pixel_id].values.extend(new_values)
+                added_events += pos_n_events
+
+            if n_events is not None and added_events >= n_events:
+                break # The required number of events have been reached.
+
+            # keep track of index in original dataset
+            original_id += 1
+            if original_id == original_length:
+                original_id = 0
+
+        # If n_events not given by user, just use natural events for each pixel instead of adding additional
+        if n_events is None:
+            break
+
+    if verbose:
+        final_pixel_length = len(np.array(ds.coords[Dim.Position].values))
+        total_events = 0
+        for pixel_id in range(n_pixels):
+            total_events += len(np.array(ds["measurement"].coords[Dim.Tof].values[pixel_id]))
+
+        print("Generated dataset after tof events are added")
+        print(ds)
+
+        print("Original data file had " + str(original_events) + " events, distributed over " + str(original_length) + " pixels.")
+        if n_events is None:
+            print("A new datafile with " + str(n_pixels) + " was requested.")
+        else:
+            print("A new datafile with " + str(n_pixels) + " with " + str(n_events) + " events was requested.")
+        print("New data file has " + str(total_events) + " events, distributed over " + str(final_pixel_length) + " pixels.")
+
+        if math.fabs(total_events - expected_events)/total_events > 0.1 and n_events is None:
+            print("With linear scaling, it was expected to get " + str(expected_events) + ", yet the result was more than 10% off.")
+        if n_events is not None and math.fabs(total_events - n_events)/total_events > 0.03:
+            print("With linear scaling, it was expected to get " + str(expected_events) + ", yet the result was more than 3% off.")
+
+    return ds

--- a/test_expand_load.py
+++ b/test_expand_load.py
@@ -1,0 +1,18 @@
+import expand_load
+
+"""
+This file contains examples for loading a WISH event based nexus file with scipp
+and expanding it to higher pixel and event counts.
+
+Was tested with mantid 4.0.0 on python 3.6 and scipp
+The following command was used to create the necessary environment:
+conda create -n scipp_mantid_env -c scipp/label/dev -c mantid scipp mantid-framework python=3.6
+"""
+
+data = expand_load.expand_data_file('../../wish_event_data/WISH00043525.nxs', 3E5, n_events=6E8, verbose=True)
+
+# tested cases
+#data = expand_load.expand_data_file('../../wish_event_data/WISH00043525.nxs', 6E5)
+#data = expand_load.expand_data_file('../../wish_event_data/WISH00043525.nxs', 3E5, n_events=6E8, verbose=True)
+#data = expand_load.expand_data_file('../../wish_event_data/WISH00043525.nxs', 3E5, n_events=6E8, time_noise_us=500, verbose=True)
+#data = expand_load.expand_data_file('../../wish_event_data/WISH00043525.nxs', 3E5, n_events=6E8, time_noise_us=100, verbose=True)

--- a/test_expand_load.py
+++ b/test_expand_load.py
@@ -1,18 +1,84 @@
+import os
+import sys
+import getopt
 import expand_load
 
-"""
-This file contains examples for loading a WISH event based nexus file with scipp
-and expanding it to higher pixel and event counts.
+def main(argv):
+    """
+    This python function loads an event based nexus file with scipp and mantid
+    which is then expanded to a higher pixel and event count. Random noise is
+    added to the time of flight information to avoid exact duplication of
+    events.  Command line arguments are used to set the filename, number of
+    pixels, number of events and the width of the random distribution used for
+    the time noise.
 
-Was tested with mantid 4.0.0 on python 3.6 and scipp
-The following command was used to create the necessary environment:
-conda create -n scipp_mantid_env -c scipp/label/dev -c mantid scipp mantid-framework python=3.6
-"""
+    -f or --file= : sets the Filename
+    -p or --pixels= : sets the number of pixels (scientific notation allowed)
+    -e or --events= : sets the number of events (scientific notation allowed)
+    -t or --noise= : sets the noise width in us (scientific notation allowed)
+    -v : sets verbose mode
+    -h : shows help in terminal
 
-data = expand_load.expand_data_file('../../wish_event_data/WISH00043525.nxs', 3E5, n_events=6E8, verbose=True)
+    Was tested with mantid 4.0.0 on python 3.6 and scipp
+    The following command was used to create the necessary environment:
+    conda create -n scipp_mantid_env -c scipp/label/dev -c mantid scipp mantid-framework python=3.6
+    """
 
-# tested cases
-#data = expand_load.expand_data_file('../../wish_event_data/WISH00043525.nxs', 6E5)
-#data = expand_load.expand_data_file('../../wish_event_data/WISH00043525.nxs', 3E5, n_events=6E8, verbose=True)
-#data = expand_load.expand_data_file('../../wish_event_data/WISH00043525.nxs', 3E5, n_events=6E8, time_noise_us=500, verbose=True)
-#data = expand_load.expand_data_file('../../wish_event_data/WISH00043525.nxs', 3E5, n_events=6E8, time_noise_us=100, verbose=True)
+    filename = None # set with -f or --file=
+    n_pixels = None # set with -p or --pixels=
+    n_events = None # set with -e or --events=
+    time_noise_us = None # set with -t or --noise
+    verbose = False # set with -v
+
+    try:
+        opts, args = getopt.getopt(argv, "hf:p:e:t:v",["file=", "pixels=", "events=", "noise="])
+    except getopt.GetoptError:
+        print("Error in input, use -h for more information.")
+        print("test_expand_load.py -f <filename> -p <n pixels> -e <n events> -t <time noise us>")
+        sys.exit(2)
+    for opt, arg in opts:
+        if opt == "-h":
+            print("-"*5 + " HELP " + "-"*66)
+            print("test_expand_load.py -f <filename> -p <n pixels> -e <n events> -t <time noise>")
+            print("Long options: --file= --pixels= --events= --noise=")
+            print("verbose mode: -v")
+            print("filename and n pixels are required.")
+            print("Can only increase number of pixels and number of events per pixel.")
+            sys.exit()
+        elif opt in ("-f", "--file"):
+            filename = arg
+        elif opt in ("-p", "--pixels"):
+            n_pixels = arg
+        elif opt in ("-e", "--events"):
+            n_events = arg
+        elif opt in ("-t", "--noise"):
+            time_noise_us = arg
+        elif opt == "-v":
+            verbose = True
+
+    if filename is None:
+        print("test_expand_load.py -f <filename> -p <n pixels> -e <n events> -t <time noise>")
+        raise ValueError("No filename is choosen, set -f or --file option.")
+
+    if not os.path.isfile(filename):
+        raise ValueError("No file with path: \"" + filename + "\" found.")
+
+    if n_pixels is None:
+        print("test_expand_load.py -f <filename> -p <n pixels> -e <n events> -t <time noise>")
+        raise ValueError("No number of pixels choosen, set -p or --pixels option.")
+
+    # By converting to float, scientific notation is allowed in input
+    n_pixels = float(n_pixels)
+    if time_noise_us is not None:
+        time_noise_us = float(time_noise_us)
+    if n_events is not None:
+        n_events = float(n_events)
+
+    if time_noise_us is None: # If time noise not given, use default of function
+        data = expand_load.expand_data_file(filename, n_pixels, n_events=n_events, verbose=verbose)
+    else:
+        data = expand_load.expand_data_file(filename, n_pixels, n_events=n_events,
+                                            time_noise_us=time_noise_us, verbose=verbose)
+
+if __name__ == "__main__":
+    main(sys.argv[1:]) # drop script name from arguments


### PR DESCRIPTION
expand this to more pixels / events by replicating the existing
pixels / events. Random noise is added to the event times in order
to avoid perfect overlap in that regard.

A quick test script is available that just runs the function with
a reasonable set of inputs.

No data file is included as all data files we have available can
not be shared due to the ISIS data policy. A datafile for inhouse
testing is available through ownCloud.