### PR TITLE
Updated ess examples for latest version of scipp

### DIFF
--- a/dream.py
+++ b/dream.py
@@ -129,7 +129,7 @@ class DreamTest:
             'position':
             sc.Variable(dims=[Dim.Row],
                         values=[source_pos, sample_pos],
-                        unit=sc.units.m, dtype=sc.dtype.vector_3_double)
+                        unit=sc.units.m, dtype=sc.dtype.vector_3_float64)
         })
         return component_info
 
@@ -215,7 +215,7 @@ class DreamTest:
         # Use this to initialize the pixel coordinates
         pixel_coords = sc.Variable(dims=[Dim.Position],
                                    values=pixel_positions,
-                                   unit=sc.units.m, dtype=sc.dtype.vector_3_double)
+                                   unit=sc.units.m, dtype=sc.dtype.vector_3_float64)
 
         if write_calibration:
             self.cal["tzero"] = sc.Variable(dims=[Dim.Position], values=np.zeros(n_pixel_per_row*n_rows), unit=sc.units.us)

--- a/dream_demo.ipynb
+++ b/dream_demo.ipynb
@@ -186,20 +186,6 @@
    "metadata": {},
    "outputs": [],
    "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/expand_load.py
+++ b/expand_load.py
@@ -48,7 +48,7 @@ def expand_data_file(filename, n_pixels, n_events=None, time_noise_us=200, verbo
         print("Loaded dataset")
         print(d)
 
-    original_length = len(np.array(d.coords[Dim.Position].values))
+    original_length = len(np.array(d.coords[Dim.Spectrum].values))
     original_events = 0
     for pixel_id in range(original_length):
         original_events += len(np.array(d["loaded_data"].coords[Dim.Tof].values[pixel_id]))
@@ -64,23 +64,23 @@ def expand_data_file(filename, n_pixels, n_events=None, time_noise_us=200, verbo
 
     # Adding pixels to dataset
     current_length = original_length
-    positions_var = d.coords[Dim.Position]
+    positions_var = d.coords[Dim.Spectrum]
     combined_var = positions_var.copy()
     while (current_length <= n_pixels - original_length):
         current_length += original_length
-        combined_var = sc.concatenate(combined_var, positions_var, Dim.Position)
+        combined_var = sc.concatenate(combined_var, positions_var, Dim.Spectrum)
 
     remaining_length = n_pixels - current_length
 
     if remaining_length > 0:
-        combined_var = sc.concatenate(combined_var, positions_var[Dim.Position, 0:remaining_length], Dim.Position)
+        combined_var = sc.concatenate(combined_var, positions_var[Dim.Spectrum, 0:remaining_length], Dim.Spectrum)
 
     # Create sparse tof data
-    tofs = sc.Variable(dims=[Dim.Position, Dim.Tof], shape=[n_pixels, sc.Dimensions.Sparse], unit=sc.units.us)
+    tofs = sc.Variable(dims=[Dim.Spectrum, Dim.Tof], shape=[n_pixels, sc.Dimensions.Sparse], unit=sc.units.us)
     # Create new dataset with new positions and tof sparse data
-    ds = sc.DataArray(coords={Dim.Position: combined_var, Dim.Tof: tofs})
-    # Keep component_info from loaded data manually
-    ds.labels["component_info"] = d.labels["component_info"]
+    ds = sc.DataArray(coords={Dim.Spectrum: combined_var, Dim.Tof: tofs})
+    # Keep detector_info from loaded data manually
+    ds.labels["detector_info"] = d.labels["detector_info"]
 
     if verbose:
         print("Generated dataset before tof events are added")
@@ -99,7 +99,7 @@ def expand_data_file(filename, n_pixels, n_events=None, time_noise_us=200, verbo
                 noise = np.random.normal(pos_n_events, scale=time_noise_us)
                 new_values = np.array(d["loaded_data"].coords[Dim.Tof].values[original_id]) + noise
 
-                ds.coords[Dim.Tof][Dim.Position, pixel_id].values.extend(new_values)
+                ds.coords[Dim.Tof][Dim.Spectrum, pixel_id].values.extend(new_values)
                 added_events += pos_n_events
 
             if n_events is not None and added_events >= n_events:
@@ -115,7 +115,7 @@ def expand_data_file(filename, n_pixels, n_events=None, time_noise_us=200, verbo
             break
 
     if verbose:
-        final_pixel_length = len(np.array(ds.coords[Dim.Position].values))
+        final_pixel_length = len(np.array(ds.coords[Dim.Spectrum].values))
         total_events = 0
         for pixel_id in range(n_pixels):
             total_events += len(np.array(ds.coords[Dim.Tof].values[pixel_id]))

--- a/powder_reduction_convert_with_cal.py
+++ b/powder_reduction_convert_with_cal.py
@@ -2,7 +2,7 @@ import scipp as sc
 from scipp import Dim
 
 
-def powder_reduction(data, calibration=None):
+def powder_reduction_convert_with_cal(data, calibration=None):
     """
     Takes a dataset with tof data and detector positions and converts to
     d-spacing. Can use calibration data which needs to contain the fields

--- a/smooth_data_demo.ipynb
+++ b/smooth_data_demo.ipynb
@@ -254,7 +254,49 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.7.6"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
+  },
+  "varInspector": {
+   "cols": {
+    "lenName": 16,
+    "lenType": 16,
+    "lenVar": 40
+   },
+   "kernels_config": {
+    "python": {
+     "delete_cmd_postfix": "",
+     "delete_cmd_prefix": "del ",
+     "library": "var_list.py",
+     "varRefreshCmd": "print(var_dic_list())"
+    },
+    "r": {
+     "delete_cmd_postfix": ") ",
+     "delete_cmd_prefix": "rm(",
+     "library": "var_list.r",
+     "varRefreshCmd": "cat(var_dic_list()) "
+    }
+   },
+   "types_to_exclude": [
+    "module",
+    "function",
+    "builtin_function_or_method",
+    "instance",
+    "_Feature"
+   ],
+   "window_display": false
   }
  },
  "nbformat": 4,

--- a/spline_demo.ipynb
+++ b/spline_demo.ipynb
@@ -156,13 +156,6 @@
    "metadata": {},
    "outputs": [],
    "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -181,7 +174,49 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.7.6"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
+  },
+  "varInspector": {
+   "cols": {
+    "lenName": 16,
+    "lenType": 16,
+    "lenVar": 40
+   },
+   "kernels_config": {
+    "python": {
+     "delete_cmd_postfix": "",
+     "delete_cmd_prefix": "del ",
+     "library": "var_list.py",
+     "varRefreshCmd": "print(var_dic_list())"
+    },
+    "r": {
+     "delete_cmd_postfix": ") ",
+     "delete_cmd_prefix": "rm(",
+     "library": "var_list.r",
+     "varRefreshCmd": "cat(var_dic_list()) "
+    }
+   },
+   "types_to_exclude": [
+    "module",
+    "function",
+    "builtin_function_or_method",
+    "instance",
+    "_Feature"
+   ],
+   "window_display": false
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The examples related to the "ESS" implementations (Python scripts and Jupyter notebooks) have been updated to run with the most recent version of scipp (0.2-553).